### PR TITLE
fix: correct verse ordering in fi-hawa-khairil-ibad

### DIFF
--- a/sholawat/tunggal/fi-hawa-khairil-ibad.json
+++ b/sholawat/tunggal/fi-hawa-khairil-ibad.json
@@ -9,16 +9,16 @@
       "latin": "Fī hawā khairil-ʿibād — syuġifal-qalbu wa hām"
     },
     "2": {
-      "arabic": "فَهَنِيْئًا لِفُؤَادٍ — قَدْ بَتَّ صَوْبًا مُسْتَهَامْ",
-      "latin": "Fa hanīʾan li fuʾādin — qad batta ṣhauban mustahām"
+      "arabic": "فَهَنِيْئًا لِفُؤَادٍ — نَالَ منْ طه الْمَرَامُ",
+      "latin": "Fa hanīʾan li fuʾādin — nāla min Ṭhāhāl-marām"
     },
     "3": {
-      "arabic": "أَنَا فِي مَدْحِ مُحَمَّدٍ — نَالَ منْ طه الْمَرَامُ",
-      "latin": "Anā fī madḥi Muḥammad — nāla min Ṭhāhāl-marām"
+      "arabic": "أَنَا فِي مَدْحِ مُحَمَّدٍ — مُغْرَمٌ وَاللهُ يَشْهَدْ",
+      "latin": "Anā fī madḥi Muḥammad — mughramun wallāhu yasyhad"
     },
     "4": {
-      "arabic": "أَنَا فِيْ أَوْصَافِهِ — مُغْرَمٌ وَاللهُ يَشْهَدْ",
-      "latin": "Anā fī ʾauṣhāfihi — mughramun wallāhu yasyhad"
+      "arabic": "أَنَا فِيْ أَوْصَافِهِ — قَدْ بَتَّ صَوْبًا مُسْتَهَامْ",
+      "latin": "Anā fī ʾauṣhāfihi — qad batta ṣhauban mustahām"
     }
   },
   "translations": {
@@ -27,11 +27,11 @@
       "translator": "kitabkuning.id",
       "text": {
         "1": "Dalam cinta hamba terbaik — Hatiku terpikat dan mabuk",
-        "2": "Berbahagialah hati — Yang telah menjadi mabuk cinta sejati",
-        "3": "Aku dalam memuji Muhammad — Telah mencapai tujuan dari Ṭāhā",
-        "4": "Aku dalam mengagumi sifat-sifatnya — Tergila-gila dan Allah Maha Mengetahui"
+        "2": "Berbahagialah hati — Yang telah mencapai tujuan dari Ṭāhā",
+        "3": "Aku dalam memuji Muhammad — Tergila-gila dan Allah Maha Mengetahui",
+        "4": "Aku dalam mengagumi sifat-sifatnya — Yang telah menjadi mabuk cinta sejati"
       }
     }
   },
-  "last_updated": "2025-11-21"
+  "last_updated": "2026-07-14"
 }


### PR DESCRIPTION
Rotated the second halves of verses 2, 3, and 4 to their proper positions to match the correct Arabic recitation order. Updated last_updated date.